### PR TITLE
fixed incorrect property - always returned NaN

### DIFF
--- a/dist/notify.js
+++ b/dist/notify.js
@@ -392,7 +392,7 @@
 				incr(css, pos, margin);
 			}
 		}
-		gap = Math.max(0, this.options.gap - (this.options.arrowShow ? arrowSize : 0));
+		gap = Math.max(0, this.options.gap - (this.options.arrowShow ? this.options.arrowSize : 0));
 		incr(css, oppFull, gap);
 		if (!this.options.arrowShow) {
 			this.arrow.hide();


### PR DESCRIPTION
was using "arrowSize" when it should actually be "this.options.arrowSize"